### PR TITLE
fix: Rhapsody generator use_module_names and message name bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosar-calltree"
-version = "0.8.0"
+version = "0.8.1"
 description = "A Python tool to analyze C/AUTOSAR codebases and generate function call trees with Mermaid and XMI output"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/autosar_calltree/generators/rhapsody_generator.py
+++ b/src/autosar_calltree/generators/rhapsody_generator.py
@@ -359,11 +359,7 @@ class RhapsodyXmiGenerator:
                 return
 
             # Determine source participant
-            if depth == 0:
-                # Root function calls itself (initialization)
-                source_name = node.function_info.name
-            else:
-                source_name = self._get_participant_name(node.function_info)
+            source_name = self._get_participant_name(node.function_info)
 
             # Process each child call
             for child in node.children:
@@ -422,7 +418,7 @@ class RhapsodyXmiGenerator:
                 message = SubElement(interaction, "message")
                 message.set(f"{{{self.XMI_NAMESPACE}}}type", "uml:Message")
                 message.set(f"{{{self.XMI_NAMESPACE}}}id", message_id)
-                message.set("name", f"message_{message_index}")
+                message.set("name", child.function_info.name)
                 message.set("receiveEvent", target_occ_id)
                 message.set("sendEvent", source_occ_id)
                 message.set(

--- a/src/autosar_calltree/version.py
+++ b/src/autosar_calltree/version.py
@@ -1,5 +1,5 @@
 """Version information for autosar-calltree package."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __author__ = "melodypapa"
 __email__ = "melodypapa@outlook.com"

--- a/tests/unit/generators/test_rhapsody_generator.py
+++ b/tests/unit/generators/test_rhapsody_generator.py
@@ -778,9 +778,6 @@ class TestRhapsodyXmiGenerator:
             output_path.unlink()
 
     # Test module-level diagram
-    @pytest.mark.skip(
-        reason="Test needs update for lxml XML structure - generator works correctly"
-    )
     def test_module_level_diagram(self):
         """Test module-level lifelines."""
         generator = RhapsodyXmiGenerator(use_module_names=True)


### PR DESCRIPTION
Fixed two bugs in the Rhapsody XMI generator:

1. --use-module-names KeyError: The root node in _create_messages() was using node.function_info.name directly instead of calling _get_participant_name(), which caused a KeyError when use_module_names was enabled because lifeline_elements was keyed by module names.

2. Generic message names: Messages were named "message_0", "message_1" instead of showing the actual function names being called. Changed to use child.function_info.name for consistency with XMI generator.

Changes:
- rhapsody_generator.py: Use _get_participant_name() for all nodes
- rhapsody_generator.py: Use function name for message name
- test_rhapsody_generator.py: Enable test_module_level_diagram

Version: 0.8.0 -> 0.8.1 (PATCH)

Files modified:
- src/autosar_calltree/generators/rhapsody_generator.py
- tests/unit/generators/test_rhapsody_generator.py
- src/autosar_calltree/version.py
- pyproject.toml

Test Coverage: 392 passed, 11 skipped, 89% coverage