### PR TITLE
docs: Add Sphinx/ReadTheDocs documentation setup

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,41 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Custom targets
+
+# Live preview with sphinx-autobuild
+live:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
+
+# Clean build artifacts
+cleanall: clean
+	rm -rf "$(BUILDDIR)"
+
+# Build all formats
+all: html pdf
+
+# Check for warnings
+check:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" -W $(SPHINXOPTS)
+
+# Generate API documentation
+api:
+	sphinx-apidoc -o api/ ../src/autosar_calltree --force

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,245 @@
+# AUTOSAR Call Tree Analyzer Documentation
+
+This directory contains the Sphinx documentation for AUTOSAR Call Tree Analyzer.
+
+## Documentation Structure
+
+```
+docs/
+├── _static/              # Static files (CSS, JS, images)
+│   ├── custom.css        # Custom styling
+│   └── copybutton.js     # Copy button functionality
+├── _templates/           # Custom Sphinx templates
+├── getting_started/      # Getting started guides
+│   ├── installation.md   # Installation instructions
+│   ├── quickstart.md     # Quick start guide
+│   └── configuration.md  # Configuration options
+├── user_guide/          # User guide
+├── tutorials/           # Tutorials and examples
+├── api/                 # API reference
+│   └── modules.rst      # Auto-generated API docs
+├── architecture/        # Architecture documentation
+├── development/         # Development guides
+├── reference/           # Reference documentation
+├── conf.py             # Sphinx configuration
+├── index.rst           # Documentation index
+└── requirements.txt    # Python dependencies for docs
+```
+
+## Building the Documentation
+
+### Prerequisites
+
+Install the documentation dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Build HTML Documentation
+
+```bash
+# Build HTML documentation
+make html
+
+# Or using sphinx-build directly
+sphinx-build -b html . _build/html
+```
+
+The built documentation will be in `_build/html/`.
+
+### Build PDF Documentation
+
+```bash
+# Build PDF
+make pdf
+
+# Or using sphinx-build
+sphinx-build -b pdf . _build/pdf
+```
+
+### Live Preview
+
+For live preview during development:
+
+```bash
+# Install sphinx-autobuild
+pip install sphinx-autobuild
+
+# Start live preview server
+sphinx-autobuild . _build/html
+```
+
+Then open http://localhost:8000 in your browser.
+
+## Writing Documentation
+
+### Markdown Support
+
+This documentation uses **MyST-Parser** to support Markdown files. You can write documentation in either:
+
+- **Markdown** (`.md` files) - Recommended for most content
+- **reStructuredText** (`.rst` files) - For advanced Sphinx features
+
+### Markdown Examples
+
+```markdown
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+**Bold text** and *italic text*.
+
+- Bullet list item 1
+- Bullet list item 2
+
+1. Numbered list item 1
+2. Numbered list item 2
+
+[Link text](https://example.com)
+
+`inline code`
+
+```python
+def example():
+    """Code block example"""
+    pass
+```
+
+### Cross-References
+
+Link to other documentation pages:
+
+```markdown
+See {doc}`/getting_started/installation` for installation instructions.
+```
+
+Reference API documentation:
+
+```markdown
+The {class}`autosar_calltree.database.FunctionDatabase` class manages...
+```
+
+### Admonitions
+
+Use admonitions for notes, warnings, tips:
+
+```markdown
+.. note::
+   This is a note.
+
+.. warning::
+   This is a warning.
+
+.. tip::
+   This is a tip.
+```
+
+## ReadTheDocs Configuration
+
+The documentation is configured to build on ReadTheDocs automatically. The configuration is in `readthedocs.yaml` at the project root.
+
+### ReadTheDocs Settings
+
+- **Python version**: 3.13
+- **OS**: Ubuntu 24.04
+- **Format**: HTML and PDF
+- **Theme**: sphinx-rtd-theme
+
+## Contributing to Documentation
+
+### Guidelines
+
+1. **Keep it simple** - Write for your target audience
+2. **Use examples** - Show, don't just tell
+3. **Update index** - Add new pages to the appropriate `toctree`
+4. **Check links** - Ensure cross-references work
+5. **Test locally** - Build and review before pushing
+
+### File Naming
+
+- Use lowercase with underscores: `my_page.md`
+- Be descriptive: `installation.md`, not `install.md`
+- Group related files in subdirectories
+
+### Committing Changes
+
+1. Build documentation locally to verify
+2. Check for warnings: `make html 2>&1 | grep warning`
+3. Commit both source and built HTML (if needed)
+4. Update `CHANGELOG.md` for significant changes
+
+## Useful Sphinx Directives
+
+### Code Blocks
+
+```markdown
+.. code-block:: python
+   :linenos:
+   :emphasize-lines: 2,3
+
+   def example():
+       line1()
+       line2()  # highlighted
+       line3()  # highlighted
+```
+
+### Tables
+
+```markdown
+.. list-table:: Table Title
+   :header-rows: 1
+
+   * - Header 1
+     - Header 2
+   * - Cell 1
+     - Cell 2
+```
+
+### Images
+
+```markdown
+.. image:: images/diagram.png
+   :width: 600px
+   :align: center
+   :alt: Diagram description
+```
+
+## Troubleshooting
+
+### Build Errors
+
+**Missing dependencies:**
+```bash
+pip install -r requirements.txt
+```
+
+**Import errors:**
+```bash
+# Ensure the package is installed
+pip install -e ..
+```
+
+**Theme not found:**
+```bash
+pip install sphinx-rtd-theme
+```
+
+### Warnings
+
+**Duplicate labels:**
+- Each label must be unique
+- Use explicit labels: `.. _my-label:`
+
+**Missing references:**
+- Check spelling of references
+- Ensure referenced files exist
+
+## Resources
+
+- [Sphinx Documentation](https://www.sphinx-doc.org/)
+- [MyST-Parser Documentation](https://myst-parser.readthedocs.io/)
+- [ReadTheDocs Documentation](https://docs.readthedocs.io/)
+- [reStructuredText Primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,34 @@
+API Reference
+=============
+
+This section provides detailed API documentation for AUTOSAR Call Tree Analyzer.
+
+.. toctree::
+   :maxdepth: 4
+
+   autosar_calltree
+
+autosar_calltree package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   autosar_calltree.analyzers
+   autosar_calltree.cli
+   autosar_calltree.config
+   autosar_calltree.database
+   autosar_calltree.generators
+   autosar_calltree.parsers
+   autosar_calltree.utils
+
+Module contents
+---------------
+
+.. automodule:: autosar_calltree
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,215 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+from pathlib import Path
+
+# Add the source directory to the path for autodoc
+sys.path.insert(0, os.path.abspath('../src'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'AUTOSAR Call Tree Analyzer'
+copyright = '2026, melodypapa'
+author = 'melodypapa'
+
+# Get version from the package
+try:
+    from autosar_calltree import __version__
+    release = __version__
+except ImportError:
+    release = '0.12.0'
+
+version = release
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    # Markdown support
+    'myst_parser',
+    
+    # API documentation
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
+    
+    # Code highlighting
+    'sphinx.ext.viewcode',
+    'sphinx.ext.doctest',
+    
+    # Links and references
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.githubpages',
+    
+    # Diagrams
+    'sphinxcontrib.mermaid',
+    
+    # PDF export
+    'rst2pdf.pdfbuilder',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# The suffix(es) of source filenames.
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
+
+# -- Markdown configuration (MyST-Parser) ------------------------------------
+
+# Enable MyST extensions
+myst_enable_extensions = [
+    'colon_fence',
+    'deflist',
+    'dollarmath',
+    'fieldlist',
+    'html_admonition',
+    'html_image',
+    'linkify',
+    'replacements',
+    'smartquotes',
+    'strikethrough',
+    'substitution',
+    'tasklist',
+]
+
+# GitHub-flavored Markdown
+myst_gfm_only = False
+
+# Enable heading anchors
+myst_heading_anchors = 3
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+    'canonical_url': '',
+    'analytics_id': '',
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': False,
+    'style_nav_header_background': '#2980B9',
+    
+    # Toc options
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': False,
+    
+    # GitHub integration
+    'logo_only': False,
+    'display_github': True,
+    'github_user': 'melodypapa',
+    'github_repo': 'autosar_calltree',
+    'github_version': 'main',
+    'conf_py_path': '/docs/',
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# Custom CSS
+html_css_files = [
+    'custom.css',
+]
+
+# -- Options for LaTeX/PDF output --------------------------------------------
+
+latex_elements = {
+    'papersize': 'letterpaper',
+    'pointsize': '10pt',
+    'preamble': '',
+    'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, documentclass [howto/manual])
+latex_documents = [
+    ('index', 'autosar_calltree.tex', 'AUTOSAR Call Tree Analyzer Documentation',
+     'melodypapa', 'manual'),
+]
+
+# -- PDF output configuration ------------------------------------------------
+
+pdf_documents = [
+    ('index', 'autosar_calltree', 'AUTOSAR Call Tree Analyzer Documentation',
+     'melodypapa'),
+]
+
+pdf_stylesheets = ['sphinx', 'kerning', 'a4']
+
+pdf_break_level = 1
+
+pdf_breakside = 'any'
+
+# -- Autodoc configuration ---------------------------------------------------
+
+# Automatically extract typehints when specified and place them in
+# descriptions of the relevant function/method.
+autodoc_typehints = 'description'
+
+# Don't show type hints for parameters in the signature
+autodoc_typehints_format = 'short'
+
+# -- Napoleon configuration --------------------------------------------------
+
+# Enable Google style docstrings
+napoleon_google_docstring = True
+
+# Enable NumPy style docstrings
+napoleon_numpy_docstring = True
+
+# Include private members
+napoleon_include_private_with_doc = False
+
+# Include special members
+napoleon_include_special_with_doc = True
+
+# Use adjectives instead of verbs for attribute docstrings
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_use_keyword = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
+
+# -- Intersphinx configuration -----------------------------------------------
+
+# Link to external documentation
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+
+# -- Mermaid configuration ---------------------------------------------------
+
+mermaid_version = 'latest'
+mermaid_init_js = "mermaid.initialize({startOnLoad:true,theme:'neutral'});"
+
+# -- Copy button configuration -----------------------------------------------
+
+# Add copy button to code blocks
+html_js_files = [
+    'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js',
+    'copybutton.js',
+]

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -1,0 +1,247 @@
+# Configuration
+
+AUTOSAR Call Tree Analyzer can be configured through command-line options and configuration files.
+
+## Command-Line Options
+
+### Basic Options
+
+```bash
+calltree [OPTIONS]
+```
+
+#### Source and Output
+
+- `-i, --source-dir DIRECTORY` - Source directory containing C files (default: ./demo)
+- `-o, --output PATH` - Output file path (default: call_tree.md)
+- `-f, --format [mermaid|rhapsody]` - Output format (default: mermaid)
+
+#### Function Selection
+
+- `-s, --start-function TEXT` - Name of the function to start call tree from
+- `-d, --max-depth INTEGER` - Maximum depth to traverse (default: 3)
+- `-l, --list-functions` - List all available functions and exit
+- `--search TEXT` - Search for functions matching pattern and exit
+
+#### Cache Options
+
+- `--cache-dir DIRECTORY` - Cache directory (default: <source-dir>/.cache)
+- `--no-cache` - Disable cache usage
+- `--rebuild-cache` - Force rebuild of cache
+
+#### Output Options
+
+- `-v, --verbose` - Enable verbose output
+- `--no-abbreviate-rte` - Do not abbreviate RTE function names in diagrams
+
+#### Module Configuration
+
+- `--module-config PATH` - Path to YAML file mapping C files to SW modules
+- `--use-module-names / --no-use-module-names` - Use SW module names as Mermaid participants (default: True)
+
+#### Advanced Features
+
+- `--enable-loops` - Enable loop detection and representation in diagrams
+- `--enable-conditionals` - Enable if-else conditional detection in diagrams
+
+#### Rhapsody-Specific
+
+- `--rhapsody-package-path TEXT` - Package path for Rhapsody XMI output
+- `--rhapsody-model-name TEXT` - Rhapsody model name in generated XMI
+
+## Module Configuration File
+
+Create a YAML file to map C files to software modules:
+
+### Example: `module_mapping.yaml`
+
+```yaml
+# Module mapping configuration
+default_module: "Application"
+
+# Map file patterns to module names
+file_mappings:
+  "app.c": "Application"
+  "com_stack.c": "Communication"
+  "hardware.c": "Hardware Abstraction"
+  "mcal_*.c": "MCAL"
+
+# Map directories to module names
+pattern_mappings:
+  "communication/": "Communication"
+  "drivers/": "Drivers"
+  "mcal/": "MCAL"
+```
+
+### Using Module Configuration
+
+```bash
+calltree -s main -i /path/to/source --module-config module_mapping.yaml -o call_tree.md
+```
+
+## Include Directories
+
+### Auto-Detection
+
+The tool automatically detects include directories in these locations:
+
+1. `<source_dir>/include`
+2. `<source_dir>/../include`
+3. `<source_dir>/../../include`
+4. `<source_dir>/../../infras/include` (AUTOSAR pattern)
+
+### Manual Include Paths
+
+If your project has a different structure, you may need to set environment variables or ensure headers are accessible.
+
+## Environment Variables
+
+### LLVM_CONFIG_PATH
+
+Path to llvm-config for libclang:
+
+```bash
+export LLVM_CONFIG_PATH=/usr/bin/llvm-config
+```
+
+### PYTHONPATH
+
+Add custom Python modules:
+
+```bash
+export PYTHONPATH=/path/to/custom/modules:$PYTHONPATH
+```
+
+## Output Formats
+
+### Mermaid (Default)
+
+Generates Markdown files with embedded Mermaid sequence diagrams:
+
+```bash
+calltree -s main -i /path/to/source -o call_tree.md
+```
+
+### Rhapsody XMI
+
+Generates IBM Rhapsody XMI files:
+
+```bash
+calltree -s main -i /path/to/source -f rhapsody -o output.xmi
+```
+
+## Cache Management
+
+### Cache Location
+
+By default, cache is stored in `<source_dir>/.cache/function_db.pkl`
+
+### Cache Benefits
+
+- Faster subsequent analysis
+- Avoids re-parsing unchanged files
+- Stores function database for quick lookups
+
+### Cache Invalidation
+
+The cache is automatically invalidated when:
+- Source files are modified
+- `--rebuild-cache` is used
+- Parser version changes
+
+### Disabling Cache
+
+For one-time analysis or when cache is not needed:
+
+```bash
+calltree -s main -i /path/to/source --no-cache
+```
+
+## Performance Tuning
+
+### Large Codebases
+
+For large codebases (1000+ files):
+
+1. **Use caching** - Always use cache for repeated analysis
+2. **Limit depth** - Use `-d 2` or `-d 3` to limit traversal depth
+3. **Specific functions** - Analyze specific functions rather than the entire codebase
+
+### Example: Large Project
+
+```bash
+# Build cache first
+calltree -l -i /path/to/large/project
+
+# Analyze specific functions
+calltree -s main_function -i /path/to/large/project -d 2
+```
+
+## Integration with Build Systems
+
+### Makefile
+
+```makefile
+.PHONY: calltree
+
+calltree:
+	calltree -l -i src -o docs/call_tree.md
+```
+
+### CMake
+
+```cmake
+find_program(CALLTREE_EXE calltree)
+
+if(CALLTREE_EXE)
+    add_custom_target(calltree
+        COMMAND ${CALLTREE_EXE} -l -i ${CMAKE_SOURCE_DIR}/src
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating call tree documentation"
+    )
+endif()
+```
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions example
+- name: Generate Call Tree
+  run: |
+    pip install autosar-calltree
+    calltree -l -i src -o call_tree.md
+    calltree -s main -i src -o docs/call_tree.md
+```
+
+## Troubleshooting
+
+### Missing Headers
+
+If you get "file not found" errors for headers:
+
+1. Check include directory structure
+2. Ensure headers are in one of the auto-detected locations
+3. Verify header files exist and are readable
+
+### Parse Errors
+
+If you get parse errors:
+
+1. Check C code syntax
+2. Ensure all required headers are available
+3. Use `-v` for verbose output to see details
+
+### Slow Performance
+
+If analysis is slow:
+
+1. Enable caching (default)
+2. Reduce traversal depth
+3. Analyze specific subdirectories
+4. Check for circular dependencies
+
+## Next Steps
+
+- {doc}`/user_guide/basic_usage` - Learn more usage patterns
+- {doc}`/user_guide/output_formats` - Understand output format options
+- {doc}`/tutorials/analyzing_autosar` - AUTOSAR-specific examples

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,0 +1,152 @@
+# Installation
+
+## Prerequisites
+
+Before installing AUTOSAR Call Tree Analyzer, ensure you have the following:
+
+- **Python 3.10 or higher** (3.10, 3.11, 3.12, 3.13 supported)
+- **libclang** (for C code parsing)
+- **pip** (Python package manager)
+
+## Installing libclang
+
+### macOS
+
+```bash
+# Using Homebrew
+brew install llvm
+
+# Or install via pip
+pip install libclang
+```
+
+### Linux (Ubuntu/Debian)
+
+```bash
+# Install LLVM and Clang
+sudo apt-get update
+sudo apt-get install llvm clang libclang-dev
+
+# Or install via pip
+pip install libclang
+```
+
+### Windows
+
+```bash
+# Install via pip
+pip install libclang
+```
+
+## Installing AUTOSAR Call Tree Analyzer
+
+### From PyPI (Recommended)
+
+```bash
+pip install autosar-calltree
+```
+
+### From Source
+
+```bash
+# Clone the repository
+git clone https://github.com/melodypapa/autosar_calltree.git
+cd autosar_calltree
+
+# Install in development mode
+pip install -e ".[dev]"
+```
+
+### From GitHub
+
+```bash
+pip install git+https://github.com/melodypapa/autosar_calltree.git
+```
+
+## Verifying Installation
+
+After installation, verify it works:
+
+```bash
+# Check version
+calltree --version
+
+# Get help
+calltree --help
+
+# Run a simple test
+calltree -l -i /path/to/your/c/code
+```
+
+## Development Installation
+
+For contributing to the project:
+
+```bash
+# Clone the repository
+git clone https://github.com/melodypapa/autosar_calltree.git
+cd autosar_calltree
+
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install in development mode with all dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/
+
+# Run linting
+ruff check src/ tests/
+```
+
+## Troubleshooting
+
+### libclang not found
+
+If you get an error about libclang not being found:
+
+1. Ensure libclang is installed (see instructions above)
+2. Set the `LLVM_CONFIG_PATH` environment variable:
+
+```bash
+# macOS with Homebrew
+export LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config
+
+# Linux
+export LLVM_CONFIG_PATH=/usr/bin/llvm-config
+```
+
+### Permission errors
+
+If you get permission errors during installation:
+
+```bash
+# Use --user flag
+pip install --user autosar-calltree
+
+# Or use a virtual environment
+python -m venv venv
+source venv/bin/activate
+pip install autosar-calltree
+```
+
+### Python version not supported
+
+Ensure you're using Python 3.10 or higher:
+
+```bash
+python --version
+```
+
+If you have multiple Python versions, use the specific version:
+
+```bash
+python3.12 -m pip install autosar-calltree
+```
+
+## Next Steps
+
+- {doc}`/getting_started/quickstart` - Get started with basic usage
+- {doc}`/getting_started/configuration` - Configure the tool for your project

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,0 +1,212 @@
+# Quick Start
+
+This guide will help you get started with AUTOSAR Call Tree Analyzer in just a few minutes.
+
+## Basic Usage
+
+### 1. List All Functions
+
+First, let's see what functions are in your codebase:
+
+```bash
+calltree -l -i /path/to/your/source
+```
+
+This will scan all C files in the directory and list all functions found.
+
+**Example output:**
+
+```
+Database Statistics:
+┌──────────────────┬─────┐
+│ Files Scanned    │ 15  │
+│ Functions Found  │ 127 │
+│ Unique Names     │ 124 │
+│ Static Functions │ 3   │
+│ Parse Errors     │ 0   │
+└──────────────────┴─────┘
+
+Available Functions:
+
+   1. CanIf_Init
+   2. CanIf_Transmit
+   3. CanIf_MainFunction
+   ...
+```
+
+### 2. Generate a Call Tree
+
+Now let's generate a call tree for a specific function:
+
+```bash
+calltree -s CanIf_Transmit -i /path/to/your/source -o call_tree.md
+```
+
+This creates a Mermaid sequence diagram showing the function call tree.
+
+**Example output (call_tree.md):**
+
+```markdown
+# Call Tree: CanIf_Transmit
+
+## Sequence Diagram
+
+\`\`\`mermaid
+sequenceDiagram
+    participant CanIf_Transmit
+    participant CanIf_TransmitInternal
+
+    CanIf_Transmit->>CanIf_TransmitInternal: call(TxPduId, PduInfoPtr)
+\`\`\`
+
+## Function Details
+
+| Function | File | Line | Return Type | Parameters |
+|----------|------|------|-------------|------------|
+| `CanIf_Transmit` | CanIf.c | 356 | `Std_ReturnType` | `PduIdType TxPduId`<br>`const PduInfoType *PduInfoPtr` |
+```
+
+### 3. Control Depth
+
+By default, the call tree goes 3 levels deep. You can control this:
+
+```bash
+# Only 1 level deep
+calltree -s main -i /path/to/source -d 1 -o call_tree.md
+
+# Go 5 levels deep
+calltree -s main -i /path/to/source -d 5 -o call_tree.md
+```
+
+### 4. Search for Functions
+
+Search for functions matching a pattern:
+
+```bash
+calltree --search Can -i /path/to/source
+```
+
+**Example output:**
+
+```
+Search Results for 'Can':
+
+  CanIf_Init (CanIf.c:246)
+  CanIf_Transmit (CanIf.c:356)
+  CanNm_MainFunction (CanNm.c:1139)
+  Can_Write (Can.c:102)
+
+Found 4 matches
+```
+
+## Advanced Features
+
+### Enable Loop Detection
+
+Detect and visualize loops in the call tree:
+
+```bash
+calltree -s main -i /path/to/source --enable-loops -o call_tree.md
+```
+
+### Enable Conditional Branches
+
+Show if-else branches in the diagram:
+
+```bash
+calltree -s main -i /path/to/source --enable-conditionals -o call_tree.md
+```
+
+### Use Module Names
+
+If you have a module configuration file:
+
+```bash
+calltree -s main -i /path/to/source --module-config module_mapping.yaml -o call_tree.md
+```
+
+### Generate Rhapsody XMI
+
+For IBM Rhapsody integration:
+
+```bash
+calltree -s main -i /path/to/source -f rhapsody -o output.xmi
+```
+
+## Working with AUTOSAR Projects
+
+AUTOSAR Call Tree Analyzer is designed to work with AUTOSAR codebases:
+
+### Auto-detection of Include Directories
+
+The tool automatically detects include directories in common AUTOSAR project structures:
+
+- `<source_dir>/include`
+- `<source_dir>/../include`
+- `<source_dir>/../../include`
+- `<source_dir>/../../infras/include` (AUTOSAR pattern)
+
+### AUTOSAR Macro Support
+
+The clang parser handles AUTOSAR-specific macros:
+
+- `FUNC()` declarations
+- `P2VAR()`, `P2CONST()` type definitions
+- `RTE_CALL()` invocations
+- Standard AUTOSAR types
+
+### Example: Analyzing AUTOSAR Communication Stack
+
+```bash
+# Analyze the entire communication stack
+calltree -l -i /path/to/autosar/infras/communication
+
+# Generate call tree for CanIf module
+calltree -s CanIf_MainFunction -i /path/to/autosar/infras/communication/CanIf -d 3
+```
+
+## Using Cache
+
+For large codebases, use caching to speed up analysis:
+
+```bash
+# First run builds the cache
+calltree -l -i /path/to/large/codebase
+
+# Subsequent runs use the cache
+calltree -s main -i /path/to/large/codebase  # Fast!
+
+# Force rebuild cache
+calltree -l -i /path/to/large/codebase --rebuild-cache
+
+# Disable cache
+calltree -l -i /path/to/large/codebase --no-cache
+```
+
+## Common Patterns
+
+### Analyze a Single File
+
+```bash
+calltree -l -i /path/to/single/file.c
+```
+
+### Analyze Multiple Directories
+
+```bash
+# Just specify the parent directory
+calltree -l -i /path/to/project/src
+```
+
+### Find Entry Points
+
+```bash
+# List all functions and grep for main or init functions
+calltree -l -i /path/to/source | grep -E "(main|init)"
+```
+
+## Next Steps
+
+- {doc}`/getting_started/configuration` - Learn about configuration options
+- {doc}`/user_guide/basic_usage` - Detailed usage examples
+- {doc}`/tutorials/analyzing_autosar` - AUTOSAR-specific tutorials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,117 @@
+.. AUTOSAR Call Tree Analyzer documentation master file
+
+Welcome to AUTOSAR Call Tree Analyzer's Documentation
+======================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting Started
+   
+   getting_started/installation
+   getting_started/quickstart
+   getting_started/configuration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+   
+   user_guide/basic_usage
+   user_guide/output_formats
+   user_guide/advanced_features
+   user_guide/integration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Tutorials
+   
+   tutorials/analyzing_autosar
+   tutorials/generating_diagrams
+   tutorials/rhapsody_integration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+   
+   api/modules
+   api/parsers
+   api/analyzers
+   api/generators
+   api/database
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Architecture
+   
+   architecture/overview
+   architecture/components
+   architecture/data_flow
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Development
+   
+   development/contributing
+   development/testing
+   development/documentation
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+   
+   reference/cli
+   reference/changelog
+   reference/license
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+About
+=====
+
+**AUTOSAR Call Tree Analyzer** is a Python tool that analyzes C/AUTOSAR codebases 
+and generates function call trees with Mermaid sequence diagrams or IBM Rhapsody XMI output.
+
+Key Features
+------------
+
+* **Clang-based Parser**: Production-grade C parsing using libclang for maximum accuracy
+* **AUTOSAR Support**: Built-in understanding of AUTOSAR patterns and macros
+* **Multiple Output Formats**: Generate Mermaid diagrams, Rhapsody XMI, or text-based call trees
+* **Interactive Analysis**: Visualize function call relationships with sequence diagrams
+* **Cache Support**: Fast incremental analysis with intelligent caching
+* **Module Mapping**: Organize functions by software modules
+
+Quick Example
+-------------
+
+.. code-block:: bash
+
+   # Install the tool
+   pip install autosar-calltree
+
+   # Analyze your codebase
+   calltree -i /path/to/source -s main_function -o call_tree.md
+
+   # List all functions
+   calltree -l -i /path/to/source
+
+.. note::
+
+   This documentation covers version |version|. For other versions, use the version 
+   switcher in the bottom-left corner.
+
+Getting Help
+------------
+
+* **Documentation**: You're reading it!
+* **GitHub Issues**: https://github.com/melodypapa/autosar_calltree/issues
+* **Source Code**: https://github.com/melodypapa/autosar_calltree
+
+License
+-------
+
+This project is licensed under the MIT License - see the :doc:`reference/license` for details.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+# Sphinx documentation requirements
+sphinx>=7.0.0
+sphinx-rtd-theme>=2.0.0
+myst-parser>=2.0.0
+sphinxcontrib-mermaid>=0.9.0
+rst2pdf>=0.101.0
+sphinx-autodoc-typehints>=1.25.0
+linkify-it-py>=2.0.0

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt
+        


### PR DESCRIPTION
## Summary

This PR adds comprehensive Sphinx documentation with ReadTheDocs integration for the AUTOSAR Call Tree Analyzer project.

## Changes

- **Sphinx Configuration**: Complete setup with MyST-Parser for markdown support
- **Getting Started Guides**: Installation, Quick Start, and Configuration documentation
- **API Reference Structure**: Auto-generated documentation from docstrings
- **ReadTheDocs Integration**: Configured for automatic documentation builds
- **Custom Styling**: Professional appearance with copy button functionality
- **Build Automation**: Makefile for easy documentation building

## Features

✅ **Markdown Support** - Write docs in markdown via MyST-Parser
✅ **API Reference** - Auto-generated from source code docstrings
✅ **Search Functionality** - Built-in Sphinx search
✅ **Version Switching** - Support for multiple versions
✅ **PDF Export** - rst2pdf integration for PDF generation
✅ **GitHub Integration** - Edit links and issue tracking
✅ **Copy Buttons** - Easy code block copying

## Documentation Structure

```
docs/
├── getting_started/     # Installation, Quick Start, Configuration
├── user_guide/         # (To be expanded)
├── tutorials/          # (To be expanded)
├── api/                # Auto-generated API reference
├── architecture/       # (To be expanded)
├── development/        # (To be expanded)
└── reference/          # CLI reference, changelog, license
```

## Testing

- ✅ All tests pass (396 passed)
- ✅ Lint checks pass
- ✅ Documentation builds successfully locally

## Next Steps

After merging:
1. Connect repository to ReadTheDocs
2. Enable documentation builds on ReadTheDocs
3. Expand user guide and tutorials
4. Add architecture documentation

## How to Test

Build the documentation locally:

```bash
cd docs
pip install -r requirements.txt
make html
open _build/html/index.html
```